### PR TITLE
Escape <, > and & in HTML

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -9,10 +9,17 @@ git submodule foreach git pull origin master
 
 cd rust
 
-echo "<title>BitRust - Breaking Changes in rust-lang/rust</title>" > ../index.html
-echo '<pre>' >> ../index.html
-git log -n100 --grep '\[breaking-change\]' >> ../index.html
-echo '</pre>' >> ../index.html
+echo "<!DOCTYPE html><html><head>" > ../index.html
+echo "<title>BitRust - Breaking Changes in rust-lang/rust</title>" >> ../index.html
+echo '</head><body><pre>' >> ../index.html
+
+git log -n100 --grep '\[breaking-change\]' \
+  | sed -e 's/&/\&amp;/g' \
+  | sed -e 's/</\&lt;/g' \
+        -e 's/>/\&gt;/g' \
+  >> ../index.html
+
+echo '</pre></body></html>' >> ../index.html
 
 cd ..
 


### PR DESCRIPTION
Also adds `<html>` and other boilerplate tags.

I've not included an updated `index.html`.
